### PR TITLE
🐛 ブランドIDが取得できなくなっていたバグを修正

### DIFF
--- a/eroge_release/getchuya_scraping/introduction_page_scraping.rb
+++ b/eroge_release/getchuya_scraping/introduction_page_scraping.rb
@@ -77,9 +77,9 @@ module ErogeRelease
     # 対象のゲームのブランドのIDをスクレイピングする
     #   ブランドIDを取得し返す
     def scraping_brand_id(html)
-      html.css('table > tr > td > nobr > a').each do |a|
+      html.css('table > tr > td > a').each do |a|
         # 対象のゲームのブランド作品の一覧でなかったら次の要素へ
-        next unless a.text.include?('（このブランドの作品一覧）')
+        next unless a.text.include?('このブランドの作品一覧')
 
         uri = URI.parse(a[:href])
         querys = URI.decode_www_form(uri.query)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@
 require 'webmock/rspec'
 require 'simplecov'
 require 'vcr'
+require 'pry'
 
 # SimpleCovのロード処理
 SimpleCov.start


### PR DESCRIPTION
# 修正内容

- html の構造が変わったことにより、ブランドIDが 2020年6月より取得できなくなっていた
- ついでに RSpec で binding.pry が使えるようにする
    - 通常のコード内で binding.pry を使いたいが現状は使えない（ `require 'pry'` の記述が必要）